### PR TITLE
Make Vim's tmp file settings safer

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -36,13 +36,18 @@ endif
 
 """ Special File Setup """
 " Because we also want our backup files to not be all over.
-set backupdir=~/.vim/backups//
+execute 'set backupdir='$HOME.'/.vim/backups//'
+call mkdir(&backupdir, 'p', 0700)
 " Because it gets annoying when you are editing a file in Dropbox and the
 " .swp file gets shared...
-set directory=~/.vim/swaps//
+execute 'set directory='$HOME.'/.vim/swaps//'
+call mkdir(&directory, 'p', 0700)
 " Undo files.
-set undodir=~/.vim/undo//
-set undofile
+if has('persistent_undo')
+	execute 'set undodir='$HOME.'/.vim/undo//'
+	call mkdir(&undodir, 'p', 0700)
+	set undofile
+endif
 
 """ Leader Commands """
 " Change the map-leader.


### PR DESCRIPTION
The use of '\~' in constant strings to refer to the user's home directory
is replaced with "$HOME" and execute commands.  This is more robust as
"$HOME" can be always be used to refer to the home directory whereas '~'
only refer to the directory in certain cases (see `:h $HOME`).

Each `set` of a tmp file variable is accompanied by a call to `mkdir()`.
Those function calls create the preceding directory (along with parent
directories, as necessary) with permissions that restrict permissions to
the owner.

`undodir` and `undofile` only exist if Vim was compiled with the
`+persistent_undo` feature (see `:h 'undofile').  As such, the setting
of those variables should be conditional on the compilation setting.